### PR TITLE
Local automcserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,4 +50,5 @@ volumes:
 
 networks:
   loa_network:
+    name: loa_network
     driver: bridge

--- a/src/events/commands/mc-status.ts
+++ b/src/events/commands/mc-status.ts
@@ -106,8 +106,11 @@ export default class McStatus extends Command {
 
         const client = new Socket()
 
-        client.connect(env.mcPortOpener, env.mcIp, () => {
+        console.log('Request automcserver to open the Minecraft server...')
+
+        client.connect(env.mcPortOpener, 'automcserver', () => {
           client.write('Open the server')
+          console.log('Request sent.')
           client.destroy()
         })
 


### PR DESCRIPTION
el automcserver estaba usando port forwarding cuando deberia ser local, he metido ese container en la loa_network y ahora se conecta poniendo el nombre del container

tambien he puesto un par de logs para no tener delirium mirando por que no se conecta si vuelve a pasar algo